### PR TITLE
Add Dependabot auto-merge workflow with co-author attribution

### DIFF
--- a/DEPENDABOT_AUTOMERGE_SETUP.md
+++ b/DEPENDABOT_AUTOMERGE_SETUP.md
@@ -1,0 +1,63 @@
+# Dependabot Auto-Merge Setup
+
+This document explains how to set up automatic merging of Dependabot PRs with co-author attribution.
+
+## Overview
+
+The auto-merge system will:
+- Automatically merge patch and minor version updates from Dependabot
+- Include you as a co-author in the merge commits
+- Only merge safe updates (no major version changes)
+- Preserve full git history
+
+## Setup Instructions
+
+1. **Move the workflow file**: 
+   Move `dependabot-automerge.yml` to `.github/workflows/dependabot-automerge.yml`
+
+2. **Enable auto-merge permissions**:
+   - Go to your repository settings
+   - Navigate to Actions → General
+   - Under "Workflow permissions", ensure "Read and write permissions" is selected
+   - Check "Allow GitHub Actions to create and approve pull requests"
+
+3. **Configure Dependabot** (optional):
+   Create `.github/dependabot.yml` if it doesn't exist:
+   ```yaml
+   version: 2
+   updates:
+     - package-ecosystem: "pip"
+       directory: "/book_project"
+       schedule:
+         interval: "weekly"
+       open-pull-requests-limit: 5
+   ```
+
+## How It Works
+
+1. When Dependabot creates a PR, the workflow triggers
+2. It checks if the update is a patch or minor version (safe updates)
+3. If safe, it merges the PR with a commit message that includes you as co-author
+4. Major version updates require manual review
+
+## Security Considerations
+
+- Only patch and minor updates are auto-merged
+- Major version updates require manual review
+- The workflow has limited permissions
+- All changes are logged in git history
+
+## Customization
+
+You can modify the workflow to:
+- Change which update types are auto-merged
+- Adjust the co-author information
+- Add additional checks or tests before merging
+- Customize commit messages
+
+## Testing
+
+To test the setup:
+1. Create a test branch with an outdated dependency
+2. Let Dependabot create a PR for a patch/minor update
+3. Verify the auto-merge works with co-author attribution

--- a/dependabot-automerge.yml
+++ b/dependabot-automerge.yml
@@ -1,0 +1,59 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
+      repository-projects: write
+
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2.2.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Auto-merge Dependabot PRs
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: |
+          gh pr merge --auto --merge "$PR_URL" --body "🤖 Auto-merged Dependabot PR for ${{ steps.metadata.outputs.dependency-names }}"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Auto-merge with co-author
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: |
+          # Get the PR number
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          
+          # Create a merge commit with co-author
+          git config --global user.name "dependabot[bot]"
+          git config --global user.email "49699333+dependabot[bot]@users.noreply.github.com"
+          
+          # Fetch the PR
+          gh pr checkout $PR_NUMBER
+          
+          # Create merge commit with co-author trailer
+          COMMIT_MSG="Merge pull request #$PR_NUMBER from ${{ github.event.pull_request.head.ref }}
+
+${{ github.event.pull_request.title }}
+
+Co-authored-by: Tomohiro Ishibashi <tomoish@users.noreply.github.com>"
+          
+          # Switch to main and merge
+          git checkout main
+          git merge --no-ff "${{ github.event.pull_request.head.ref }}" -m "$COMMIT_MSG"
+          git push origin main
+          
+          # Close the PR
+          gh pr close $PR_NUMBER --comment "✅ Auto-merged with co-author attribution"
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to automatically merge Dependabot PRs with co-author attribution.

## Features
- Auto-merges patch and minor version updates only
- Includes co-author attribution in merge commits
- Comprehensive setup documentation

## Setup Required
The workflow file needs to be moved to `.github/workflows/` and repository permissions updated as detailed in the setup guide.

Fixes #36

Generated with [Claude Code](https://claude.ai/code)